### PR TITLE
Reintroduced WRAPPER_DIR in Makefile to make tests run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 include config.mk
 include project_version.mk
 
+WRAPPER_DIR=wrapper
 MODULES_SRC_DIR= $(addsuffix /cpp, $(addprefix $(SOURCE_DIR)/, $(MODULES)))
 SRCS:=$(foreach src_dir, $(MODULES_SRC_DIR), $(shell find $(src_dir) -name \*.cpp))
 EXPORT_HEADERS:=$(foreach module, $(addprefix $(SOURCE_DIR)/, $(MODULES)), $(shell find $(module) -maxdepth 1 -name \*.h))


### PR DESCRIPTION
The `WRAPPER_DIR` variable was removed from `Makefile` in version 0.5.0. This seems to be the reason that `make test` call fails.

Solves #5.
