### PR TITLE
Changing long to longlong.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ ifeq ($(MACHINE),x86)
 else ifeq ($(MACHINE),x64)
     CXXFLAGS+=-m64
     LD_FLAGS+=-m64
+else ifeq ($(MACHINE),arm)
 else
-    $(error Unrecognized "MACHINE" value, use 'x86' or 'x64')
+    $(error Unrecognized "MACHINE" value, use 'x86', 'x64' or 'arm')
 endif
 
 REAL_DIST_DIR:=$(DIST_DIR)/$(CONFIGURATION)/lib/$(MACHINE)

--- a/config.mk
+++ b/config.mk
@@ -9,6 +9,8 @@ ifndef MACHINE
         MACHINE:=x64
     else ifeq ($(MACHINE_RAW),amd64)
         MACHINE:=x64
+    else ifeq ($(MACHINE_RAW),armv7l)
+        MACHINE:=arm
     else
         MACHINE:=x86
     endif

--- a/wrapper/python/mbientlab/metawear/core.py
+++ b/wrapper/python/mbientlab/metawear/core.py
@@ -40,7 +40,7 @@ class DataTypeId:
 # Python wrapper for the MblMwMessage struct
 class Data(Structure):
     _fields_= [
-        ("epoch", c_long),
+        ("epoch", c_longlong),
         ("value", c_void_p),
         ("type_id", c_int),
         ("length", c_ubyte)
@@ -48,10 +48,10 @@ class Data(Structure):
 
 class GattCharacteristic(Structure):
     _fields_= [
-        ("service_uuid_high", c_ulong),
-        ("service_uuid_low", c_ulong),
-        ("uuid_high", c_ulong),
-        ("uuid_low", c_ulong)
+        ("service_uuid_high", c_ulonglong),
+        ("service_uuid_low", c_ulonglong),
+        ("uuid_high", c_ulonglong),
+        ("uuid_low", c_ulonglong)
     ]
 
 Fn_ByteArray= CFUNCTYPE(None, POINTER(c_ubyte), c_ubyte)
@@ -61,7 +61,7 @@ Fn_DataPtr= CFUNCTYPE(None, POINTER(Data))
 Fn_VoidPtr_GattCharPtr_ByteArray= CFUNCTYPE(None, c_void_p, POINTER(GattCharacteristic), POINTER(c_ubyte), c_ubyte)
 Fn_VoidPtr_GattCharPtr= CFUNCTYPE(None, c_void_p, POINTER(GattCharacteristic))
 Fn_Uint_Uint= CFUNCTYPE(None, c_uint, c_uint)
-Fn_Ubyte_Long_ByteArray= CFUNCTYPE(None, c_ubyte, c_long, POINTER(c_ubyte), c_ubyte)
+Fn_Ubyte_Long_ByteArray= CFUNCTYPE(None, c_ubyte, c_longlong, POINTER(c_ubyte), c_ubyte)
 
 # UUIDs for the MetaWear gatt services and characteristics
 class Gatt:


### PR DESCRIPTION
Enable building on Raspberry Pi by setting all `c_long` and `c_ulong` to `c_longlong` and `c_ulonglong`. Also modify Makefile and config.mk to disable -m32 flag for RPi.

Only tested on Raspberry Pi 2 (`armv7l`).

Fixes #7.